### PR TITLE
Fix rails 6 autoload deprecation notices

### DIFF
--- a/lib/redirect_on_back/engine.rb
+++ b/lib/redirect_on_back/engine.rb
@@ -1,7 +1,9 @@
 module RedirectOnBack
   class Engine < Rails::Engine
     initializer 'redirect_on_back controller extensions includes' do
-      ActionController::Base.send(:include, RedirectOnBack::ControllerAdditions)
+      ActiveSupport.on_load(:action_controller) do
+        include RedirectOnBack::ControllerAdditions
+      end
     end
   end
 end


### PR DESCRIPTION
* https://github.com/rails/rails/issues/36546
* Referencing ActionController::Base in rails initialization causes
  deprecation notices
* Use ActiveSupport.on_load to include helpers without referencing
  ActionController::Base